### PR TITLE
修正替换规则

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -99,7 +99,7 @@ class Prismjs_Plugin implements Typecho_Plugin_Interface
         if ($widget instanceof Widget_Archive || $widget instanceof Widget_Abstract_Comments) {
             $text = str_replace('<pre><code>', '<pre><code class="lang-auto">', $text);
             $text = str_replace('<pre>', '<pre class="line-numbers">', $text);
-            $text = str_replace('lang-sh', 'lang-shell', $text);
+            $text = preg_replace('/(?<=\s|-)lang-sh(?=\s|-)/', 'lang-shell', $text);
         }
 
         return $text;


### PR DESCRIPTION
避免将 `shell` 替换为 `shshell`